### PR TITLE
struct type implementation

### DIFF
--- a/samples/struct.c
+++ b/samples/struct.c
@@ -1,20 +1,28 @@
 struct MyStruct
 {
   int a;
-  int c[2];
-  int b[5];
+  int b;
+  int c;
 };
 int main()
 {
-  struct MyStruct s;
+  struct MyStruct s = { 1, 2, 3 };
 
-  s.a = 1;
-  // s.b = 2;
+  int x = { 10 };
+
+  s.a = 10;
   print(&s.a);
+  print(s.a);
+  print(s.b);
   print(s.c);
-  print(s.b);
 
-  // ++s.b;
+  ++s.c;
+  print(s.a);
   print(s.b);
+  print(s.c);
+
+  print(x);
+  x = 20;
+  print(x);
   return 0;
 }

--- a/samples/struct.c
+++ b/samples/struct.c
@@ -1,17 +1,20 @@
 struct MyStruct
 {
   int a;
-  int b;
+  int c[2];
+  int b[5];
 };
 int main()
 {
   struct MyStruct s;
 
   s.a = 1;
-  s.b = 2;
-  print(s.a);
+  // s.b = 2;
+  print(&s.a);
+  print(s.c);
   print(s.b);
-  ++s.b;
+
+  // ++s.b;
   print(s.b);
   return 0;
 }

--- a/samples/struct.c
+++ b/samples/struct.c
@@ -6,5 +6,12 @@ struct MyStruct
 int main()
 {
   struct MyStruct s;
+
+  s.a = 1;
+  s.b = 2;
+  print(s.a);
+  print(s.b);
+  ++s.b;
+  print(s.b);
   return 0;
 }

--- a/samples/struct.c
+++ b/samples/struct.c
@@ -1,0 +1,10 @@
+struct MyStruct
+{
+  int a;
+  int b;
+};
+int main()
+{
+  struct MyStruct s;
+  return 0;
+}

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -103,22 +103,9 @@ pub struct PostMember {
 impl Expression for PostMember {
     fn emit(&self, instructions: &mut InstructionGenerator) {
         let member_offset = match self.src.get_typeinfo(instructions) {
-            TypeInfo::Struct(s) => {
-                let sinfo = if s.fields.is_some() {
-                    s
-                } else {
-                    let tt = instructions
-                        .search_type(s.name.as_ref().unwrap())
-                        .expect(format!("Struct {} not found", s.name.as_ref().unwrap()).as_str());
-                    if let TypeInfo::Struct(sinfo) = tt {
-                        sinfo.clone()
-                    } else {
-                        panic!("PostMember on non-struct type");
-                    }
-                };
-
+            TypeInfo::Struct(sinfo) => {
                 let mut member_offset: Option<usize> = None;
-                for (t, name, offset) in sinfo.fields.as_ref().unwrap() {
+                for (_, name, offset) in sinfo.fields.as_ref().unwrap() {
                     if name == &self.member {
                         member_offset = Some(*offset);
                         break;

--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -236,15 +236,14 @@ impl ASTParser {
         )
         .map(
             |name: String, memberss: Vec<Vec<(String, TypeInfo)>>| -> StructInfo {
-                let mut fields: HashMap<String, (TypeInfo, usize)> = HashMap::new();
-                let mut idx: usize = 0;
+                let mut fields: Vec<(TypeInfo, String, usize)> = Vec::new();
+                let mut offset: usize = 0;
                 for members in memberss.into_iter() {
                     for member in members.into_iter() {
-                        let old = fields.insert(member.0.clone(), (member.1.clone(), idx));
-                        idx += member.1.number_of_primitives();
-                        if old.is_some() {
-                            panic!("Duplicated field name: {}", member.0);
-                        }
+                        fields.push((member.1.clone(), member.0.clone(), offset));
+                        offset += member.1.number_of_primitives();
+
+                        // TODO duplicate check
                     }
                 }
                 StructInfo {
@@ -260,15 +259,14 @@ impl ASTParser {
             rp::one(Token::RightBrace).void()
         )
         .map(|memberss: Vec<Vec<(String, TypeInfo)>>| -> StructInfo {
-            let mut fields: HashMap<String, (TypeInfo, usize)> = HashMap::new();
-            let mut idx: usize = 0;
+            let mut fields: Vec<(TypeInfo, String, usize)> = Vec::new();
+            let mut offset: usize = 0;
             for members in memberss.into_iter() {
                 for member in members.into_iter() {
-                    let old = fields.insert(member.0.clone(), (member.1.clone(), idx));
-                    idx += member.1.number_of_primitives();
-                    if old.is_some() {
-                        panic!("Duplicated field name: {}", member.0);
-                    }
+                    fields.push((member.1.clone(), member.0.clone(), offset));
+                    offset += member.1.number_of_primitives();
+
+                    // TODO duplicate check
                 }
             }
             StructInfo {

--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -1212,8 +1212,8 @@ impl ASTParser {
                 rp::seq!(
                     rp::one(Token::LeftBrace).void(),
                     initalizer_list,
-                    rp::one(Token::RightBrace).void(),
-                    rp::one(Token::Comma).optional().void()
+                    rp::one(Token::Comma).optional().void(),
+                    rp::one(Token::RightBrace).void()
                 ),
                 self.assignment_expression.clone()
             );

--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -236,10 +236,12 @@ impl ASTParser {
         )
         .map(
             |name: String, memberss: Vec<Vec<(String, TypeInfo)>>| -> StructInfo {
-                let mut fields: HashMap<String, TypeInfo> = HashMap::new();
+                let mut fields: HashMap<String, (TypeInfo, usize)> = HashMap::new();
+                let mut idx: usize = 0;
                 for members in memberss.into_iter() {
                     for member in members.into_iter() {
-                        let old = fields.insert(member.0.clone(), member.1);
+                        let old = fields.insert(member.0.clone(), (member.1.clone(), idx));
+                        idx += member.1.number_of_primitives();
                         if old.is_some() {
                             panic!("Duplicated field name: {}", member.0);
                         }
@@ -258,10 +260,12 @@ impl ASTParser {
             rp::one(Token::RightBrace).void()
         )
         .map(|memberss: Vec<Vec<(String, TypeInfo)>>| -> StructInfo {
-            let mut fields: HashMap<String, TypeInfo> = HashMap::new();
+            let mut fields: HashMap<String, (TypeInfo, usize)> = HashMap::new();
+            let mut idx: usize = 0;
             for members in memberss.into_iter() {
                 for member in members.into_iter() {
-                    let old = fields.insert(member.0.clone(), member.1);
+                    let old = fields.insert(member.0.clone(), (member.1.clone(), idx));
+                    idx += member.1.number_of_primitives();
                     if old.is_some() {
                         panic!("Duplicated field name: {}", member.0);
                     }

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -564,7 +564,7 @@ impl Statement for DeclarationStatement {
                             instructions.declare_variable(
                                 declaration.0.as_ref().unwrap(),
                                 &TypeInfo::Array(type_.clone(), Some(size)),
-                                size,
+                                size * type_.number_of_primitives(),
                             );
 
                             // init with initializer
@@ -723,7 +723,7 @@ impl Statement for DeclarationStatement {
                             instructions.declare_variable(
                                 declaration.0.as_ref().unwrap(),
                                 &TypeInfo::Array(type_.clone(), Some(size)),
-                                size,
+                                size * type_.number_of_primitives(),
                             );
 
                             for _ in 0..size {

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -706,10 +706,7 @@ impl Statement for DeclarationStatement {
                                 size * type_.number_of_primitives(),
                             );
 
-                            for _ in 0..size {
-                                // push to stack
-                                type_.emit_default(instructions);
-                            }
+                            TypeInfo::Array(type_.clone(), Some(size)).emit_default(instructions);
                         }
 
                         // primitive types + pointer

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -493,49 +493,29 @@ impl Statement for DeclarationStatement {
         for declaration in &self.vars {
             if declaration.0.is_none() && declaration.2.is_none() {
                 // Struct & Enum & Union declaration
-                panic!("Struct & Enum & Union declaration is not allowed in declaration statement");
-                // match &declaration.1 {
-                // TypeInfo::Struct(t) => {
-                //     if t.name.is_none() {
-                //         println!("Anonymous struct in declaration statement; ignored it");
-                //     } else {
-                //         let old = instructions.cur_scope_mut().type_infos.insert(
-                //             t.name.as_ref().unwrap().clone(),
-                //             TypeInfo::Struct(t.clone()),
-                //         );
-                //         if old.is_some() {
-                //             panic!("Struct {} already exists", t.name.as_ref().unwrap());
-                //         }
-                //     }
-                // }
-                // TypeInfo::Union(t) => {
-                //     if t.name.is_none() {
-                //         println!("Anonymous union in declaration statement; ignored it");
-                //     } else {
-                //         let old = instructions.cur_scope_mut().type_infos.insert(
-                //             t.name.as_ref().unwrap().clone(),
-                //             TypeInfo::Union(t.clone()),
-                //         );
-                //         if old.is_some() {
-                //             panic!("Union {} already exists", t.name.as_ref().unwrap());
-                //         }
-                //     }
-                // }
-                // TypeInfo::Enum(t) => {
-                //     if t.name.is_none() {
-                //         println!("Anonymous enum in declaration statement; ignored it");
-                //     } else {
-                //         let old = instructions.cur_scope_mut().type_infos.insert(
-                //             t.name.as_ref().unwrap().clone(),
-                //             TypeInfo::Enum(t.clone()),
-                //         );
-                //         if old.is_some() {
-                //             panic!("Enum {} already exists", t.name.as_ref().unwrap());
-                //         }
-                //     }
-                // }
-                // _ => panic!("Invalid type for anonymous declaration"),
-                // }
+                // panic!("Struct & Enum & Union declaration is not allowed in declaration statement");
+                match &declaration.1 {
+                    TypeInfo::Struct(t) => {
+                        if t.name.is_none() {
+                            println!("Anonymous struct in declaration statement; ignored it");
+                        } else {
+                            let old = if instructions.scopes.is_empty() {
+                                &mut instructions.global_scope
+                            } else {
+                                instructions.scopes.last_mut().unwrap()
+                            }
+                            .type_infos
+                            .insert(
+                                t.name.as_ref().unwrap().clone(),
+                                TypeInfo::Struct(t.clone()),
+                            );
+                            if old.is_some() {
+                                panic!("Struct {} already exists", t.name.as_ref().unwrap());
+                            }
+                        }
+                    }
+                    _ => panic!("Invalid type for type declaration: {:?}", declaration.1),
+                }
             } else if declaration.0.is_none() {
                 panic!("Anonymous variable is not allowed in declaration statement");
             } else {
@@ -551,7 +531,7 @@ impl Statement for DeclarationStatement {
                         }
                         TypeInfo::Struct(_sinfo) => {
                             panic!(
-                                "Struct declaration in declaration statement is not implemented"
+                                "Struct variable declaration in declaration statement is not implemented"
                             );
                         }
                         TypeInfo::Union(_uinfo) => {

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -593,9 +593,7 @@ impl Statement for DeclarationStatement {
                             }
                             for _ in 0..init_with_default {
                                 // push to stack
-                                instructions.push(PushStack {
-                                    operand: Operand::Value(VariableData::init_default(type_)),
-                                });
+                                type_.emit_default(instructions);
                             }
                         }
 
@@ -708,26 +706,7 @@ impl Statement for DeclarationStatement {
                                 size,
                             );
 
-                            if let TypeInfo::Struct(sinfo) = sinfo {
-                                for i in 0..size {
-                                    // push to stack
-                                    // search for i-th field
-                                    for (field_type, field_idx) in
-                                        sinfo.fields.as_ref().unwrap().values()
-                                    {
-                                        if field_idx == &i {
-                                            instructions.push(PushStack {
-                                                operand: Operand::Value(
-                                                    VariableData::init_default(field_type),
-                                                ),
-                                            });
-                                            break;
-                                        }
-                                    }
-                                }
-                            } else {
-                                panic!("Struct is not defined");
-                            }
+                            sinfo.emit_default(instructions);
                         }
                         TypeInfo::Union(_uinfo) => {
                             panic!("Union declaration in declaration statement is not implemented");
@@ -749,9 +728,7 @@ impl Statement for DeclarationStatement {
 
                             for _ in 0..size {
                                 // push to stack
-                                instructions.push(PushStack {
-                                    operand: Operand::Value(VariableData::init_default(type_)),
-                                });
+                                type_.emit_default(instructions);
                             }
                         }
 
@@ -775,9 +752,7 @@ impl Statement for DeclarationStatement {
                             );
 
                             // push default value to stack
-                            instructions.push(PushStack {
-                                operand: Operand::Value(VariableData::init_default(&declaration.1)),
-                            });
+                            declaration.1.emit_default(instructions);
                         }
                         _ => {}
                     }

--- a/src/ast/typename.rs
+++ b/src/ast/typename.rs
@@ -142,9 +142,9 @@ impl TypeInfo {
                     .downcast_ref::<InitializerListExpression>()
                     .expect("TypeInfo::emit_init: initializer is not InitializerListExpression");
 
-                if initializer.initializers.len() != *n {
+                if initializer.initializers.len() > *n {
                     panic!(
-                        "TypeInfo::emit_init: initializer length mismatch: expected {}, got {}",
+                        "Array initialization overflow: expected {}, got {}",
                         n,
                         initializer.initializers.len()
                     );
@@ -152,6 +152,11 @@ impl TypeInfo {
 
                 for i in 0..initializer.initializers.len() {
                     t.emit_init(instructions, &initializer.initializers[i]);
+                }
+
+                let remaining = *n - initializer.initializers.len();
+                for _ in 0..remaining {
+                    t.emit_default(instructions);
                 }
             }
 

--- a/src/virtualmachine/instruction/generation.rs
+++ b/src/virtualmachine/instruction/generation.rs
@@ -132,6 +132,17 @@ impl InstructionGenerator {
         }
         None
     }
+    pub fn search_type(&self, name: &str) -> Option<&TypeInfo> {
+        for scope in self.scopes.iter().rev() {
+            if let Some(type_info) = scope.type_infos.get(name) {
+                return Some(type_info);
+            }
+        }
+        if let Some(type_info) = self.global_scope.type_infos.get(name) {
+            return Some(type_info);
+        }
+        None
+    }
 
     // link label name to current instruction address
     pub fn set_label(&mut self, label: &str) {

--- a/src/virtualmachine/variable.rs
+++ b/src/virtualmachine/variable.rs
@@ -22,23 +22,6 @@ impl Default for VariableData {
 }
 
 impl VariableData {
-    // pub fn assign(&mut self, rhs: VariableData) {}
-    pub fn init_default(typeinfo: &TypeInfo) -> VariableData {
-        match typeinfo {
-            TypeInfo::Int8 => VariableData::Int8(0),
-            TypeInfo::Int16 => VariableData::Int16(0),
-            TypeInfo::Int32 => VariableData::Int32(0),
-            TypeInfo::Int64 => VariableData::Int64(0),
-            TypeInfo::UInt8 => VariableData::UInt8(0),
-            TypeInfo::UInt16 => VariableData::UInt16(0),
-            TypeInfo::UInt32 => VariableData::UInt32(0),
-            TypeInfo::UInt64 => VariableData::UInt64(0),
-            TypeInfo::Float32 => VariableData::Float32(0.0),
-            TypeInfo::Float64 => VariableData::Float64(0.0),
-            TypeInfo::Pointer(_) => VariableData::UInt64(0),
-            _ => panic!("VariableData::init_default: {:?}", typeinfo),
-        }
-    }
     pub fn cast_to(&self, typeinfo: &TypeInfo) -> Option<VariableData> {
         match self {
             VariableData::UInt8(lu8) => match typeinfo {


### PR DESCRIPTION
added struct type implementation #2 
 - struct type declaration `struct MyStruct { int a, int b, ... }; `
 - struct variable initialize with default value `struct MyStruct a;`
 - struct variable initialize with initializer list `struct MyStruct a = { 10, 20, 30 };`
 - member access `a.field1 = 10;`

fix Pointer Inc, Dec arithmetic #6
 - `++` or `--` operation on pointer variable now increase by the number of primitive types of Pointer

fix Initializer_list parsing grammar
 - it was '{' initializer_list '}' ','
 - fix to '{' initializer_list ','? '}'